### PR TITLE
cross-freedesktop: rename dependency MesaLib to mesa

### DIFF
--- a/glu/Buildfile
+++ b/glu/Buildfile
@@ -5,7 +5,7 @@ name=glu
 version=9.0.0
 release=1
 source=ftp://ftp.freedesktop.org/pub/mesa/$name/$name-$version.tar.bz2
-depends=(MesaLib)
+depends=(mesa)
 
 build() {
    cd $name-$version


### PR DESCRIPTION
Signed-off-by: Lad, Prabhakar <prabhakar.csengg@gmail.com>